### PR TITLE
Fix screenshot URLs from master to main branch

### DIFF
--- a/visualisations/budget-sunburst/README.md
+++ b/visualisations/budget-sunburst/README.md
@@ -2,5 +2,5 @@
 
 The following is a small test of how a sunburst diagram in D3 can be used to visualise spending data.
 
-![Screenshot](https://github.com/oliveryh/toybox/blob/master/visualisations/budget-sunburst/screenshot.png)
+![Screenshot](https://github.com/oliveryh/toybox/blob/main/visualisations/budget-sunburst/screenshot.png)
 

--- a/visualisations/github-reviews/README.md
+++ b/visualisations/github-reviews/README.md
@@ -2,7 +2,7 @@
 
 A tool to generate visualisations of the number of reviews being sent between contributors of GitHub repos. The success rate (ratio of approvals against change requests), is also indicated by the colour of the edges between nodes.
 
-![Screenshot](https://github.com/oliveryh/toybox/blob/master/visualisations/github-reviews/screenshot.png)
+![Screenshot](https://github.com/oliveryh/toybox/blob/main/visualisations/github-reviews/screenshot.png)
 
 # Installation
 


### PR DESCRIPTION
## Summary
- Fixes #16 by updating screenshot image URLs in README files from the old `master` branch to the current `main` branch
- Updates two README files that were broken after the repository's default branch was renamed from `master` to `main`